### PR TITLE
Require same PHP version as the latest Zend Framework version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
 composer.lock
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 
 php:
-  - 5.5
-  - 5.4
+  - 5.6
+  - 7.0
 
 before_script:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
+        "php": "^5.6 || ^7.0",
         "zendframework/zend-mvc": "2.*",
         "zendframework/zend-form": "2.*",
         "zendframework/zend-db": "2.*",


### PR DESCRIPTION
From version 2.0 we should require the same version as Zend 3